### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/jsonrpc_io_client.dart
+++ b/lib/jsonrpc_io_client.dart
@@ -47,7 +47,7 @@ class ServerProxy extends ServerProxyBase {
     String jsonContent = '';
     Completer c = new Completer();
 
-    response.transform(utf8.decoder).listen((dynamic contents) {
+    utf8.decoder.bind(response).listen((dynamic contents) {
       jsonContent += contents.toString();
     }, onDone: () {
       if (response.statusCode == 204 || jsonContent.isEmpty) {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
